### PR TITLE
Fix #5 - Add explicit nullable types to fix PHP 8 deprecation warnings

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -11,7 +11,7 @@ class Config {
 
     public function __construct(protected $db = null) { }
 
-    public function get(string $name = null) {
+    public function get(?string $name = null) {
         if (!$name) {
             return false;
         }

--- a/src/Func.php
+++ b/src/Func.php
@@ -6,7 +6,8 @@ use Ihidzhov\FaaS\Trigger;
 
 class Func {
 
-    public function __construct(protected $db = null) { }
+    public function __construct(protected $db = null) {}
+ 
  
     public function getAll() {
         $result = $this->db->query('SELECT * FROM fn');
@@ -17,7 +18,7 @@ class Func {
         return $data;
     }
 
-    public function get(int|null $id = null) {
+    public function get(?int $id = null) {
         if (!$id) {
             return false;
         }
@@ -27,7 +28,7 @@ class Func {
         return $result->fetchArray(\SQLITE3_ASSOC);
     }
 
-    public function getByName(string $str = null) {
+    public function getByName(?string $str = null) {
         if (!$str) {
             return false;
         }

--- a/src/Log.php
+++ b/src/Log.php
@@ -31,7 +31,7 @@ class Log {
 
     }
 
-    public static function getMany($dbLogs, int $offset = 0, int $limit = 10, $search = false, string $order = "DESC") {
+    public static function getMany($dbLogs, int $offset = 0, int $limit = 10, ?string $search = null, string $order = "DESC") {
         try {
             $where = "";
             if ($search) {

--- a/src/Page.php
+++ b/src/Page.php
@@ -11,7 +11,7 @@ class Page {
     protected $siteTheme = Preferences::SITE_THEME_DEFAULT;
     protected $editorTheme = Preferences::EDITOR_THEME_DEFAULT;
 
-    public function display(string $template = null, array $vars = []) :never {
+    public function display(?string $template = null, array $vars = []) :never {
         if (!file_exists(TEMPLATES_DIR . $template . '.php')) {
             throw new Exception("Templage \"{$template}.php\" does not exists");
         }

--- a/src/Preferences.php
+++ b/src/Preferences.php
@@ -40,7 +40,7 @@ class Preferences {
     
     public function __construct(protected $db = null) { }
 
-    public function getOne(string $name = null) {
+    public function getOne(?string $name = null) {
         if (!$name || !isset(self::THEME_ARRAY[$name])) {
             throw new Exception("The name must be provided or valid");
         }


### PR DESCRIPTION
This PR fixes deprecation warnings in PHP 8.1+ related to implicitly nullable parameters.

In several functions, parameters were given a default value of `null` without explicitly declaring them as nullable types. This triggers the following warning in PHP 8.1+:

```
Deprecated: Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead
```

The affected parameters have been updated to use the explicit nullable type syntax (`?type`) to ensure compatibility with PHP 8 and above.
