### PR TITLE
Fixing typo on "lambda"

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -7,7 +7,7 @@ use json_last_error;
 
 class Config {
 
-    const FUNCTIONS_KEY = "labmda";
+    const FUNCTIONS_KEY = "lambda";
 
     public function __construct(protected $db = null) { }
 


### PR DESCRIPTION
The key being used, `labmda`, is a typo for `lambda`, and it generates a "Trying to access array offset on false" error in `http.php` on line 24.

Fixing it to `lambda`